### PR TITLE
fix: disable Enter key submission on mobile devices

### DIFF
--- a/src/chat/controls.rs
+++ b/src/chat/controls.rs
@@ -1,5 +1,7 @@
 use leptos::{html, prelude::*};
 
+use crate::dom_utils::is_mobile_device;
+
 #[component]
 pub fn ChatControls(
     #[prop(into)] input: Signal<String>,
@@ -23,10 +25,14 @@ pub fn ChatControls(
                         on:input:target=move |ev| set_input(ev.target().value())
                         placeholder="Message"
                         node_ref=ref_input
+                        enterkeyhint="send"
                         on:keydown:target=move |ev| {
                             if ev.key() == "Enter" && !ev.shift_key() && !input_disabled.get() {
-                                ev.prevent_default();
-                                submit.run(None);
+                                // On mobile devices, Enter should add newlines, not submit
+                                if !is_mobile_device() {
+                                    ev.prevent_default();
+                                    submit.run(None);
+                                }
                             }
                         }
                         disabled=input_disabled

--- a/src/dom_utils.rs
+++ b/src/dom_utils.rs
@@ -165,3 +165,23 @@ pub fn set_html_content_with_copy_buttons(target_element: &HtmlElement, html_con
         }
     }
 }
+
+/// Detects if the user is on a mobile device based on media queries.
+/// Uses CSS media query to detect pointer type and hover capability.
+/// Returns true for mobile/touch devices, false for desktop.
+pub fn is_mobile_device() -> bool {
+    let window = window();
+    
+    // Check for coarse pointer (touch) and no hover capability
+    let media_query = "(pointer: coarse) and (hover: none)";
+    
+    match window.match_media(media_query) {
+        Ok(Some(media_query_list)) => media_query_list.matches(),
+        _ => {
+            // Fallback: check if touch events are supported
+            // This is less reliable but better than nothing
+            let has_touch = js_sys::Reflect::has(&window, &"ontouchstart".into()).unwrap_or(false);
+            has_touch
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12

Implemented mobile-specific Enter key behavior for chat inputs:

- Add mobile detection utility using CSS media queries
- Modify chat controls to allow Enter for newlines on mobile
- Add enterkeyhint='send' for better mobile keyboard UX
- Keep submit button behavior unchanged as requested

Generated with [Claude Code](https://claude.ai/code)